### PR TITLE
Fix a connection bug

### DIFF
--- a/CallKitDemo/AppDelegate.swift
+++ b/CallKitDemo/AppDelegate.swift
@@ -9,6 +9,7 @@
 import UIKit
 import PushKit
 import CallKit
+import OpenTok
 
 let apiKey = ""
 let sessionId = ""
@@ -51,6 +52,8 @@ extension AppDelegate: PKPushRegistryDelegate {
             let handle = payload.dictionaryPayload["handle"] as? String,
             let uuid = UUID(uuidString: uuidString) {
             
+            OTAudioDeviceManager.setAudioDevice(DefaultAudioDevice.sharedInstance)
+                
             // display incoming call UI when receiving incoming voip notification
             let backgroundTaskIdentifier = UIApplication.shared.beginBackgroundTask(expirationHandler: nil)
             self.displayIncomingCall(uuid: uuid, handle: handle, hasVideo: false) { _ in


### PR DESCRIPTION
When we awaken the phone from a cold state from a remote notification, the audio session does not get activated. The audio session has to be activated once it's received the notification. 